### PR TITLE
[python3] Adapt code for python3

### DIFF
--- a/terranet/config_api.py
+++ b/terranet/config_api.py
@@ -1,9 +1,9 @@
 from functools import partial
 
-from wifi.channel import Channel
-
 from flask import Flask, request, jsonify, abort
 from flask.helpers import locked_cached_property
+
+from .wifi.channel import Channel
 
 
 class ConfigAPI(Flask):

--- a/terranet/controller/customer_flow_matching.py
+++ b/terranet/controller/customer_flow_matching.py
@@ -6,11 +6,11 @@ from ryu.lib.packet import packet
 from ryu.lib.packet import ethernet
 from ryu.lib.packet import ipv6
 
-import mac_learning_pipeline
+from .mac_learning_pipeline import MacLearningPipeline
 from .ipv6_address_helper import IPv6AddressHelper
 
 
-class CustomerFlowMatching(mac_learning_pipeline.MacLearningPipeline):
+class CustomerFlowMatching(MacLearningPipeline):
     OFP_VERSIONS = [ofproto_v1_3.OFP_VERSION]
     SRC_MAC_TABLE = 100
     DST_MAC_TABLE = 101

--- a/terranet/controller/customer_monitor.py
+++ b/terranet/controller/customer_monitor.py
@@ -5,10 +5,10 @@ from ryu.lib import hub
 
 from influxdb import InfluxDBClient
 
-import customer_flow_matching
+from .customer_flow_matching import CustomerFlowMatching
 
 
-class CustomerMonitor(customer_flow_matching.CustomerFlowMatching):
+class CustomerMonitor(CustomerFlowMatching):
     """
     https://osrg.github.io/ryu-book/en/html/traffic_monitor.html
     """

--- a/terranet/controller/ipv6_address_helper.py
+++ b/terranet/controller/ipv6_address_helper.py
@@ -4,7 +4,7 @@ import ipaddress
 class IPv6AddressHelper:
     @classmethod
     def parse_address(cls, ip):
-        return ipaddress.IPv6Address(unicode(ip))
+        return ipaddress.IPv6Address(str(ip))
 
     @classmethod
     def prefix(cls, ip):

--- a/terranet/topo.py
+++ b/terranet/topo.py
@@ -1,3 +1,4 @@
+import itertools
 from ipmininet.iptopo import IPTopo
 from ipmininet.link import IPLink
 from .router_config import OpenrConfig, TerranetRouterDescription
@@ -68,17 +69,20 @@ class Terratopo(IPTopo):
         return self.isNodeType(node, 'is_distribution_node_60')
 
     def client_nodes(self, sort=True):
-        return filter(self.is_client_node, self.nodes(sort))
+        return list(filter(self.is_client_node,
+                           self.nodes(sort)))
 
     def distribution_nodes(self, sort=True):
         return (self.distribution_nodes_5_60(sort=sort) +
                 self.distribution_nodes_60(sort=sort))
 
     def distribution_nodes_5_60(self, sort=True):
-        return filter(self.is_distribution_node_5_60, self.nodes(sort))
+        return list(filter(self.is_distribution_node_5_60,
+                           self.nodes(sort)))
 
     def distribution_nodes_60(self, sort=True):
-        return filter(self.is_distribution_node_60, self.nodes(sort))
+        return list(filter(self.is_distribution_node_60,
+                           self.nodes(sort)))
 
     def terranodes(self, sort=True):
         return client_nodes(sort=sort) + distribution_nodes(sort=sort)

--- a/terranet/wifi/fronthaulemulator.py
+++ b/terranet/wifi/fronthaulemulator.py
@@ -99,8 +99,8 @@ class FronthaulEmulator(object):
 
     def read_komondor_files(self, directory, cls):
         config_dict = collections.OrderedDict()
-        files = filter(lambda f: f.endswith(".cfg"),
-                       sorted(os.listdir(directory)))
+        files = list(filter(lambda f: f.endswith(".cfg"),
+                            sorted(os.listdir(directory))))
         for cfg_file in files:
             path = os.path.join(directory, cfg_file)
             cfg = cls(path)

--- a/terranet/wifi/komondor_config.py
+++ b/terranet/wifi/komondor_config.py
@@ -16,13 +16,14 @@ class KomondorBaseConfig(ConfigParser):
     def optionxform(self, optionstr):
         return optionstr
 
-    def filter_sections_by_value(self, key, value):
-        sections = filter(lambda x: key in self[x] and self[x][key] == value,
-                          self.sections())
+    def sections_by_value(self, key, value):
+        sections = list(filter(lambda x: key in self[x] and self[x][key] == value,
+                               self.sections()))
         return map(lambda x: self[x], sections)
 
     def nodes(self):
-        sections = filter(lambda x: not x == "System", self.sections())
+        sections = list(filter(lambda x: not x == "System",
+                               self.sections()))
 
 
 class KomondorConfig(KomondorBaseConfig):
@@ -33,17 +34,17 @@ class KomondorConfig(KomondorBaseConfig):
         return self["System"]
 
     def access_points(self):
-        return self.filter_sections_by_value("type", "0")
+        return self.sections_by_value("type", "0")
 
     def stations(self):
-        return self.filter_sections_by_value("type", "1")
+        return self.sections_by_value("type", "1")
 
     def nodes_by_wlan_code(self, wlan_code):
-        return self.filter_sections_by_value("wlan_code", wlan_code)
+        return self.sections_by_value("wlan_code", wlan_code)
 
     def get_stations_by_access_point(self, ap):
-        return filter(lambda x: x["type"] == "1",
-                      self.nodes_by_wlan_code(ap["wlan_code"]))
+        return list(filter(lambda x: x["type"] == "1",
+                           self.nodes_by_wlan_code(ap["wlan_code"])))
 
     def wifi5_links_for_access_point(self, ap):
         return [(ap.name, sta.name)


### PR DESCRIPTION
Python 2 is dead. The code needs some adjustments for python3:

- The changes are mainly related to functions that utilize functions
  like map, filter or reduce, which return iterators in python3
- Few import statements have been adjusted
- The unicode function has been replaced by the str function
- The commit also includes some renaming in the node classes